### PR TITLE
Fix the unzip-override when deploying and fix manual deployment flow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -95,7 +95,8 @@ jobs:
             rm -rf "$docs_path"
             mkdir "$docs_path"
           fi
-          unzip docs.zip -d "$docs_path"
+          # Force unzip to override files without prompting
+          unzip -o docs.zip -d "$docs_path"
           git add "${docs_path}/*"
           staged_files=$(git diff --staged --name-only "${docs_path}")
           if [[ ! -z "$staged_files" ]]; then

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -3,11 +3,21 @@ name: Manual Deploy Evolve docs
 on: 
   workflow_dispatch:
     inputs:
-      product-key:
-        description: 'Directory name of the product under evolve/docs/'
+      product:
+        description: 'Product to deploy the docs for, evolve or ednar'
         required: true
-      download-url:
-        description: 'Download URL'
+        type: choice
+        options:
+          - "evolve"
+          - "ednar"
+      repository:
+        description: 'Repository of the project to deploy the docs for'
+        required: true
+      artifact:
+        description: 'The artifact id to deploy'
+        required: true
+      run-id:
+        description: 'The run id of the action that created the artifact'
         required: true
 jobs:
   deploy-docs:
@@ -19,4 +29,4 @@ jobs:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           repository: ${{ secrets.DOCS_REPO }}
           event-type: ${{ secrets.DOCS_REPO_EVOLVE_WORKFLOW }}
-          client-payload: '{"product_key": "${{ github.event.inputs.product-key }}", "download_url": "${{ github.event.inputs.download-url }}"}'
+          client-payload: '{"product": "${{ inputs.product}}", "repository": "${{ inputs.repository }}", "artifact": "${{ inputs.artifact }}", "run-id": "${{ inputs.run-id }}"}'


### PR DESCRIPTION
# Description

This change does 2 things:

1. It fixes the manual deploy flow to match the expected values in the regular automated flow.
2. It fixes the regular flow with an option to `unzip` to overwrite files without prompting (otherwise the deployment fails on timeout)